### PR TITLE
Adding media and blogs

### DIFF
--- a/blogs-n-media.md
+++ b/blogs-n-media.md
@@ -25,3 +25,7 @@
 
 * [Pythonic Perambulations](https://jakevdp.github.io/) - Musings and ramblings through the world of Python and beyond
 * [On the lambda](http://www.onthelambda.com/)
+
+#### Podcasts
+* [Talking Machines](http://www.thetalkingmachines.com/)
+* [Partially Dervative](http://www.partiallyderivative.com/)

--- a/blogs-n-media.md
+++ b/blogs-n-media.md
@@ -10,6 +10,10 @@
 * [R-Bloggers](http://www.r-bloggers.com/)
 * [Flowing Data](https://flowingdata.com/)
 
+#### News
+* [KDnuggets](http://www.kdnuggets.com/)
+* [FiveThirtyEight](http://fivethirtyeight.com/)
+
 #### Machine Learning
 
 * [FastML](http://fastml.com/)

--- a/blogs-n-media.md
+++ b/blogs-n-media.md
@@ -7,6 +7,8 @@
 
 * [Shape of Data](http://shapeofdata.wordpress.com/)
 * [yhat](http://blog.yhathq.com/)
+* [R-Bloggers](http://www.r-bloggers.com/)
+* [Flowing Data](https://flowingdata.com/)
 
 #### Machine Learning
 
@@ -25,6 +27,7 @@
 
 * [Pythonic Perambulations](https://jakevdp.github.io/) - Musings and ramblings through the world of Python and beyond
 * [On the lambda](http://www.onthelambda.com/)
+* [Probably Overthinking It](http://allendowney.blogspot.com/)
 
 #### Podcasts
 * [Talking Machines](http://www.thetalkingmachines.com/)


### PR DESCRIPTION
The following media outlets have been added:
R-bloggers - A blog aggregator that aggregates content from bloggers who write about R
Flowing Data- A site that publishes data visualizations on a wide range of topics
KDnuggets - A news outlet that covers business analytics, big data, data mining and data science.
FiveThirtyEight - A data driven news outlet that Nate Silver founded
Probably Overthinking It - Allen Downey's personal blog
Talking Machines - A podcast where the hosts talk about machine learning and interview machine learning experts
Partially Derivative - A podcast where two data science professionals give their commentary on 10 data science stories every episode.

If anything about this PR should be changed, please let me know!