### PR TITLE
Added missing link to the videos of Statistics I from Princeton/Coursera

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Out of personal preference and need for focus, I geared the original curriculum 
  * The Manga Guide to Linear Algebra [Book ```$19```](http://amzn.to/1n4hM5l)
 
 * **Statistics**
- * Statistics I [Princeton / Coursera](http://bit.ly/course-princeton-stats) 
+ * Statistics I [Princeton / Coursera](http://bit.ly/course-princeton-stats) [Videos on YouTube] (http://bit.ly/1U9qvBh)
  * Stats in a Nutshell [Book ```$29```](http://amzn.to/1iMnx2X)
  * Think Stats: Probability and Statistics for Programmers [Digital](http://bit.ly/ebook-thinkstats) & [Book ```$25```](http://amzn.to/RcVnTf)
  * Think Bayes [Digital](http://bit.ly/ebook-thinkbayes) & [Book ```$25```](http://amzn.to/1hmy4Cr)
@@ -179,22 +179,22 @@ _More Libraries can be found in the ["awesome machine learning"](https://github.
    * Flexible and powerful data analysis / manipulation library with labeled data structures objects, statistical functions, etc [pandas](http://bit.ly/py-pandas) & Tutorials [Python for Data Analysis / Book](http://amzn.to/Q2pI5I)
 
  * **Machine Learning Packages**
-   * [scikit-learn](http://bit.ly/py-scikit) - Tools for Data Mining & Analysis 
+   * [scikit-learn](http://bit.ly/py-scikit) - Tools for Data Mining & Analysis
 
  * **Networks Packages**
-   * [networkx](http://bit.ly/py-networkx) - Network Modeling & Viz 
+   * [networkx](http://bit.ly/py-networkx) - Network Modeling & Viz
 
  * **Statistical Packages**
    * [PyMC](http://bit.ly/py-pymc) - Bayesian Inference & Markov Chain Monte Carlo sampling toolkit
    * [Statsmodels](http://bit.ly/py-statsmodel) - Python module that allows users to explore data, estimate statistical models, and perform statistical tests
-   * [PyMVPA](http://bit.ly/py-mvpa) - Multivariate Pattern Analysis in Python 
+   * [PyMVPA](http://bit.ly/py-mvpa) - Multivariate Pattern Analysis in Python
 
  * **Natural Language Processing & Understanding**
-   * [NLTK](http://bit.ly/py-nltk) - Natural Language Toolkit 
+   * [NLTK](http://bit.ly/py-nltk) - Natural Language Toolkit
    * [Gensim](http://bit.ly/py-gensim) - Python library for topic modeling, document indexing and similarity retrieval with large corpora. Target audience is the natural language processing (NLP) and information retrieval (IR) community.
 
  * **Live Data Packages**
-   * [twython](http://bit.ly/py-twython) - Python wrapper for the Twitter API 
+   * [twython](http://bit.ly/py-twython) - Python wrapper for the Twitter API
 
  * **Visualization Packages**
    * [matplotlib](http://www.ast.uct.ac.za/~sarblyth/pythonGuide/PythonPlottingBeginnersGuide.pdf) - well-integrated with analysis and data manipulation packages like numpy and pandas
@@ -222,7 +222,7 @@ _More Libraries can be found in the ["awesome machine learning"](https://github.
 ### Resources
 
 #### Read
-* [DataTau](http://bit.ly/datatau) - The "Hacker News" of Data Science 
+* [DataTau](http://bit.ly/datatau) - The "Hacker News" of Data Science
 * [Wikipedia](http://bit.ly/1kKg0gD) - The free encyclopedia
 * [The Signal and The Noise - Nate Silver ```$15```](http://amzn.to/1hoxQoG) - Bestseller Pop Sci
 * [Zipfian Academy's List of Resources](http://bit.ly/1qoF1We)
@@ -235,7 +235,7 @@ _More Libraries can be found in the ["awesome machine learning"](https://github.
 
 #### Learn
 * [Metacademy](http://bit.ly/metacademy) - Search for a concept you want to learn
-* [Coursera](http://bit.ly/coursera-online-courses) - Online university courses 
+* [Coursera](http://bit.ly/coursera-online-courses) - Online university courses
 * [Wolfram Alpha](http://bit.ly/wolframalpha-torus) - The smart number and info cruncher
 * [Khan Academy](http://bit.ly/khan-academy-lifeinsurance) - High quality, free learning videos
 


### PR DESCRIPTION
The video lectures from Statistics I are currently not available on coursera. However, they can be found on youtube.