### PR TITLE
Updated links to UCI Machine Learning Dataset and Linear Regression

### DIFF
--- a/datasets.md
+++ b/datasets.md
@@ -2,7 +2,7 @@
 
 #### Machine Learning
 
-* [UCI Machine Learning Dataset Repository](https://archive.ics.uci.edu/ml/datasets.html)
+* [UCI Machine Learning Dataset Repository](https://archive.ics.uci.edu/ml/datasets.php)
 * [Machine Learning Dataset Repository](http://mldata.org/)
 
 #### Deep Learning

--- a/machine-learning.md
+++ b/machine-learning.md
@@ -6,7 +6,7 @@
 * [Vectorization and Features in sci-kit (ipynb)](http://nbviewer.ipython.org/github/bigsnarfdude/machineLearning/blob/master/Vectorizing.ipynb)
 
 ### Regression
-* [Linear Regression](http://alexhwoods.com/2015/07/19/guide-to-linear-regression/)
+* [Linear Regression](https://www.analyticsvidhya.com/blog/2021/10/everything-you-need-to-know-about-linear-regression/)
 
 ### Models & Methods
 


### PR DESCRIPTION
The original links seem to be dead/removed. The link is updated for UCI Machine Learning Dataset and new resource is added for Linear Regression